### PR TITLE
Fix warning on MySQL >=5.5

### DIFF
--- a/templates/root_dot_my.cnf.j2
+++ b/templates/root_dot_my.cnf.j2
@@ -1,3 +1,3 @@
 [client]
 user=root
-pass={{ mysql_root_password }}
+password={{ mysql_root_password }}


### PR DESCRIPTION
I always got this warning for every mysql command I do:

```
Warning: Using unique option prefix pass instead of password is deprecated 
and will be removed in a future release. Please use the full name instead.
```

[example](http://www.serveridol.com/2013/11/19/mysql-dump-warning-using-unique-option-prefix-pass-instead-of-password-is-deprecated/)

I don't know when this password option was introduced, so it might break on earlier versions of MySQL.
