### PR TITLE
Make secure.yml idempotent

### DIFF
--- a/tasks/secure.yml
+++ b/tasks/secure.yml
@@ -5,23 +5,30 @@
     user: root
     host: "{{item}}"
     password: "{{mysql_root_password}}"
+    login_user: root
+    login_password: ''
   with_items:
    - "{{ansible_hostname}}"
    - 127.0.0.1
    - ::1
    - localhost
   when: ansible_hostname != 'localhost'
+  ignore_errors: yes
 
 - name: MySQL | Set the root password.
   mysql_user:
     user: root
     host: "{{item}}"
     password: "{{mysql_root_password}}"
+    login_user: root
+    login_password: ''
   with_items:
    - 127.0.0.1
    - ::1
    - localhost
   when: ansible_hostname == 'localhost'
+  ignore_errors: yes
+
 
 - name: MySQL | Configure MySql for easy access as root user
   template:
@@ -36,6 +43,8 @@
     name: ""
     host: "{{item}}"
     state: absent
+    login_user: root
+    login_password: "{{mysql_root_password}}"
   with_items:
     - "{{ansible_hostname}}"
     - localhost
@@ -44,3 +53,5 @@
   mysql_db:
     name: test
     state: absent
+    login_user: root
+    login_password: "{{mysql_root_password}}"


### PR DESCRIPTION
Hi,

I have a use-case where I use Ansibles.mysql inside Vagrant, and where I may need to run `vagrant provision` several times. The provisioning kept failing on this step, because between the first run and the next ones, the root password had been edited to something else than the default, empty string.

I think providing explicit credentials for the tasks in `secure.yml`, while ignoring connection errors for two specific tasks (which are meant to be run only once, really), is a good way to make this role idempotent.