### PR TITLE
Add update_cache to the apt module task to prevent errors on outdated se...

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,4 +6,5 @@
 - name: MySQL | Make sure the MySql packages are installed
   apt:
     pkg: "{{item}}"
+    update_cache: yes
   with_items: mysql_packages


### PR DESCRIPTION
Add update_cache to the apt module task to prevent errors on outdated servers
