### PR TITLE
Use language instead of lc_messages_dir for compatibility with versions before 5.5

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@
 mysql_port: 3306
 mysql_bind_address: "0.0.0.0"
 mysql_root_password: 'pass'
+mysql_language: '/usr/share/mysql/'
 
 # Fine Tuning
 mysql_key_buffer: '16M'

--- a/templates/etc_mysql_my.cnf.j2
+++ b/templates/etc_mysql_my.cnf.j2
@@ -21,7 +21,8 @@ port        = {{ mysql_port }}
 basedir     = /usr
 datadir     = /var/lib/mysql
 tmpdir      = /tmp
-lc-messages-dir = /usr/share/mysql
+# language is for pre-5.5. In 5.5 it is an alias for lc_messages_dir.
+language = {{ mysql_language }}
 bind-address= {{ mysql_bind_address }}
 skip-external-locking
 


### PR DESCRIPTION
In MySQL 5.5 language is an alias to lc_messages_dir. Before 5.5 the configuration parameter does not exist. With this change the role would be compatible with MySQL versions before 5.5 by using language instead of lc_messages_dir and making it configurable through a variable. There are still actively supported distributions such as Debian 6.0 Squeeze that ship with a version of MySQL older than 5.5.
