### PR TITLE
Ensure that MySQL is running so connecting will not fail.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,3 +8,8 @@
     pkg: "{{item}}"
     update_cache: yes
   with_items: mysql_packages
+
+- name: MySQL | Ensure MySQL is running
+  service:
+    name: mysql
+    state: started


### PR DESCRIPTION
If MySQL happens to not be running, the role will fail when trying to set passwords or do other operations that require connectivity. Seems to me like the install.yml file is a good place to also make sure the daemon is actually up before continuing.
