### PR TITLE
Fix incompatible variable name change

### DIFF
--- a/templates/etc_mysql_my.cnf.j2
+++ b/templates/etc_mysql_my.cnf.j2
@@ -34,7 +34,7 @@ thread_stack            = {{ mysql_thread_stack }}
 thread_cache_size       = {{ mysql_cache_size }}
 myisam-recover          = {{ mysql_myisam_recover }}
 max_connections         = {{ mysql_max_connections }}
-table_cache             = {{ mysql_table_cache }}
+table_open_cache        = {{ mysql_table_cache }}
 thread_concurrency      = {{ mysql_thread_concurrency }}
 
 # ** Query Cache Configuration


### PR DESCRIPTION
table_cache was renamed to table_open_cache.

http://dev.mysql.com/doc/relnotes/mysql/5.1/en/news-5-1-3.html
