### PR TITLE
removing my.cnf parameter 'mysql_thread_concurrency'

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ mysql_cache_size: 8
 mysql_myisam_recover: 'BACKUP'
 mysql_max_connections: 100
 mysql_table_cache: 64
-mysql_thread_concurrency: 10
 mysql_query_cache_limit: '1M'
 mysql_query_cache_size: '16M'
 mysql_character_set_server: 'utf8'

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ mysql_cache_size: 8
 mysql_myisam_recover: 'BACKUP'
 mysql_max_connections: 100
 mysql_table_cache: 64
+mysql_query_cache_type: 0
 mysql_query_cache_limit: '1M'
 mysql_query_cache_size: '16M'
 mysql_character_set_server: 'utf8'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,6 @@ mysql_cache_size: 8
 mysql_myisam_recover: 'BACKUP'
 mysql_max_connections: 100
 mysql_table_cache: 64
-mysql_thread_concurrency: 10
 mysql_query_cache_limit: '1M'
 mysql_query_cache_size: '16M'
 mysql_innodb_file_per_table: 'innodb_file_per_table'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ mysql_cache_size: 8
 mysql_myisam_recover: 'BACKUP'
 mysql_max_connections: 100
 mysql_table_cache: 64
+mysql_query_cache_type: 0
 mysql_query_cache_limit: '1M'
 mysql_query_cache_size: '16M'
 mysql_innodb_file_per_table: 'innodb_file_per_table'

--- a/templates/etc_mysql_my.cnf.j2
+++ b/templates/etc_mysql_my.cnf.j2
@@ -37,6 +37,7 @@ max_connections         = {{ mysql_max_connections }}
 table_open_cache        = {{ mysql_table_cache }}
 
 # ** Query Cache Configuration
+query_cache_tpye        = {{ mysql_query_cache_type }}
 query_cache_limit       = {{ mysql_query_cache_limit }}
 query_cache_size        = {{ mysql_query_cache_size }}
 

--- a/templates/etc_mysql_my.cnf.j2
+++ b/templates/etc_mysql_my.cnf.j2
@@ -35,7 +35,6 @@ thread_cache_size       = {{ mysql_cache_size }}
 myisam-recover          = {{ mysql_myisam_recover }}
 max_connections         = {{ mysql_max_connections }}
 table_open_cache        = {{ mysql_table_cache }}
-thread_concurrency      = {{ mysql_thread_concurrency }}
 
 # ** Query Cache Configuration
 query_cache_limit       = {{ mysql_query_cache_limit }}


### PR DESCRIPTION
- parameter is useless on Linux systems
- paramter only useful on Solaris version < 9
- removed on MySQL 5.6.1 (http://bugs.mysql.com/bug.php?id=55001)

http://www.percona.com/blog/2012/06/04/thread_concurrency-doesnt-do-what-you-expect/
