### PR TITLE
Change execution order in secure.yml

### DIFF
--- a/tasks/secure.yml
+++ b/tasks/secure.yml
@@ -1,5 +1,13 @@
 # file: mysql/tasks/secure.yml
 
+- name: MySQL | Configure MySql for easy access as root user
+  template:
+    src: root_dot_my.cnf.j2
+    dest: /root/.my.cnf
+    owner: root
+    group: root
+    mode: 0600
+
 - name: MySQL | Set the root password.
   mysql_user:
     user: root
@@ -22,14 +30,6 @@
    - ::1
    - localhost
   when: ansible_hostname == 'localhost'
-
-- name: MySQL | Configure MySql for easy access as root user
-  template:
-    src: root_dot_my.cnf.j2
-    dest: /root/.my.cnf
-    owner: root
-    group: root
-    mode: 0600
 
 - name: MySQL | Remove anonymous MySQL server user
   mysql_user:


### PR DESCRIPTION
I use this role in a Vagrant dev environment where the /var/lib/mysql dir is persisted between instances of the VMs. This means that there is a scenario where the /root/.my.cnf may not exist while the mysql already does have a root password set. Placing the template task before executing any mysql_user tasks solves this.
