### PR TITLE
Refelct the build status of master, not last build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## ANXS - MySQL [![Build Status](https://travis-ci.org/ANXS/mysql.png)](https://travis-ci.org/ANXS/mysql)
+## ANXS - MySQL [![Build Status](https://travis-ci.org/ANXS/mysql.png?branch=master)](https://travis-ci.org/ANXS/mysql)
 
 Ansible role that installs MySQL on (for now) Ubuntu variants.
 Features include:


### PR DESCRIPTION
Reflect build status of master as opposed to the most recent build, this gives false negatives about the stability of this role