### PR TITLE
Add conditional to allow overriding mysql_packages

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,6 +2,7 @@
 
 - name: MySQL | Load the os specific variables
   include_vars: "{{ansible_os_family | lower}}.yml"
+  when: mysql_packages is not defined
 
 - name: MySQL | Make sure the MySql packages are installed
   apt:


### PR DESCRIPTION
This can be useful when requesting a different package version ex. mysql-server-5.6 instead of mysql-server on Ubuntu 14.04