### PR TITLE
Add notify restart mysql and flush

### DIFF
--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -7,4 +7,5 @@
     encoding: "{{ item.encoding | default('utf8') }}"
     state: present
   with_items: mysql_databases
+  notify: restart mysql
   when: mysql_databases|length > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,3 +7,4 @@
 - include: users.yml
 - include: monit.yml
   when: monit_protection is defined and monit_protection == true
+- meta: flush_handlers

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -8,4 +8,5 @@
     state: present
     host: "{{item.host | default('localhost')}}"
   with_items: mysql_users
+  notify: restart mysql
   when: mysql_users|length > 0


### PR DESCRIPTION
This change:
- adds a notify to restart mysql on database and user changes
- flushes all handlers at the end of the role.

Motivation: I was running into a scenario where other roles could not successfully complete the database transaction if the mysql service was not restarted before the attempt.
