### PR TITLE
Move apt packages to defaults and add to readme, FIXES #39

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ mysql_users:
 
 # GLOBAL Setting
 monit_protection: false                 # true or false, requires ANXS.monit
+
+# List of apt packages to install
+mysql_packages:
+  - mysql-server
+  - mysql-client
+  - python-mysqldb
 ```
 
 # Setting/Updating the root Password

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,3 +42,9 @@ mysql_databases: []
 
 # List of users to be created
 mysql_users: []
+
+# List of apt packages to install
+mysql_packages:
+  - mysql-server
+  - mysql-client
+  - python-mysqldb

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,8 +1,5 @@
 # file: mysql/tasks/install.yml
 
-- name: MySQL | Load the os specific variables
-  include_vars: "{{ansible_os_family | lower}}.yml"
-
 - name: MySQL | Add APT repository
   apt_repository: repo={{mysql_ppa}} update_cache=yes
   when: mysql_ppa != False and mysql_ppa != ""

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,6 +1,0 @@
-# file: mysql/vars/debian.yml
-
-mysql_packages:
-  - mysql-server
-  - mysql-client
-  - python-mysqldb


### PR DESCRIPTION
Move apt packages into defaults, and remove OS specific var's file as we only currently support Ubuntu in this role

Fixes https://github.com/ANXS/mysql/issues/39

This will allow you to install different mysql packages, e.g:- 
```yaml
mysql_packages:
  - mysql-client-core-5.6 
  - mysql-client-5.6
  - mysql-server-5.6
  - python-mysqldb
```

or, as in https://github.com/ANXS/mysql/issues/39

```
mysql_packages:
  - mariadb-client
  - mariadb-server
  - python-mysqldb
```