### PR TITLE
Add the ability to set ft_min_word_len.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,6 +34,9 @@ mysql_innodb_lock_wait_timeout: 50
 mysql_innodb_log_buffer_size: '1M'
 mysql_innodb_log_file_size: '5M'
 
+# Full-Text Search
+mysql_ft_min_word_len: 4
+
 # List of databases to be created
 mysql_databases: []
 

--- a/templates/etc_mysql_my.cnf.j2
+++ b/templates/etc_mysql_my.cnf.j2
@@ -82,6 +82,9 @@ innodb_log_file_size = {{ mysql_innodb_log_file_size }}
 character_set_server = {{ mysql_character_set_server }}
 collation_server = {{ mysql_collation_server }}
 
+# ** Full-Text Search
+ft_min_word_len = {{ mysql_ft_min_word_len }}
+
 [mysqldump]
 quick
 quote-names


### PR DESCRIPTION
"The minimum length of the word to be included in a MyISAM FULLTEXT index."

We needed access to this setting in our use case. Maybe it would be worthwhile to have this in mainline?