### PR TITLE
removed deprecation warnings

### DIFF
--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -6,5 +6,5 @@
     collation: "{{ item.collation | default('utf8_general_ci') }}"
     encoding: "{{ item.encoding | default('utf8') }}"
     state: present
-  with_items: mysql_databases
-  when: mysql_databases|length > 0
+  with_items: "{{ mysql_databases }}"
+  when: "{{ mysql_databases|length > 0 }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,6 +8,7 @@
   apt:
     pkg: "{{item}}"
     update_cache: yes
+    cache_valid_time: 3600
   with_items: "{{ mysql_packages }}"
 
 - name: MySQL | Ensure MySQL is running

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,7 +8,7 @@
   apt:
     pkg: "{{item}}"
     update_cache: yes
-  with_items: mysql_packages
+  with_items: "{{ mysql_packages }}"
 
 - name: MySQL | Ensure MySQL is running
   service:

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -7,5 +7,5 @@
     priv: "{{item.priv | default('*.*:ALL')}}"
     state: present
     host: "{{item.host | default('localhost')}}"
-  with_items: mysql_users
-  when: mysql_users|length > 0
+  with_items: "{{ mysql_users }}"
+  when: "{{ mysql_users|length > 0 }}"


### PR DESCRIPTION
I am using ansible version 2.0.x and using the roles, I get deprecation warnings.
The pull request just include "{{ xxx }}" where needed.

I alos added the cache timeout time - It really helps to cycle time when rerunning the playbook again and again to fix errors.