### PR TITLE
Allow resizing ib_logfiles and default to newer (larger) value for it.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 # file: mysql/defaults/main.yml
 
 # Basic settings
+mysql_config_file: /etc/mysql/my.cnf
 mysql_port: 3306
 mysql_bind_address: "0.0.0.0"
 mysql_default_root_password: ''
@@ -31,7 +32,13 @@ mysql_innodb_buffer_pool_size: '128M'
 mysql_innodb_flush_log_at_trx_commit: 1
 mysql_innodb_lock_wait_timeout: 50
 mysql_innodb_log_buffer_size: '1M'
-mysql_innodb_log_file_size: '5M'
+
+# Note that changing this for MySQL < 5.6 will be handled by stopping MySQL,
+# moving the log files files away and starting it again.
+mysql_innodb_log_file_size: '48M'
+
+# Polling delay for MySQL after restart for changing mysql_innodb_log_file_size.
+mysql_remove_ib_logfile_startup_delay: 5
 
 # Full-Text Search
 mysql_ft_min_word_len: 4

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,11 +1,36 @@
 # file: mysql/tasks/configure.yml
 
+- name: Check if the current innodb_log_file_size is already in use.
+  command: grep 'innodb_log_file_size = {{ mysql_innodb_log_file_size }}' {{ mysql_config_file }}
+  register: innodb_log_file_size_changed
+  changed_when: "innodb_log_file_size_changed.rc != 0"
+  failed_when: "innodb_log_file_size_changed.rc >= 2"
+  always_run: yes
+
+- name: MySQL | Get MySQL version.
+  mysql_variables:
+    variable: version
+  register: mysql_version
+  always_run: yes
+
+- name: MySQL | Ensure innodb_fast_shutdown is not 2 if changing InnoDB log size.
+  mysql_variables:
+    variable: innodb_fast_shutdown
+  register: mysql_current_innodb_fast_shutdown
+  when: innodb_log_file_size_changed.rc == 1 and (mysql_version.msg[0][1] | version_compare('5.6.8', 'lt'))
+  failed_when: mysql_current_innodb_fast_shutdown.msg[0][1] == "2"
+  always_run: yes
+
 - name: MySQL | Update the my.cnf
   template:
     src: etc_mysql_my.cnf.j2
-    dest: /etc/mysql/my.cnf
+    dest: "{{ mysql_config_file }}"
     owner: root
     group: root
     mode: 0644
   notify:
     - restart mysql
+
+- name: MySQL | Remove InnoDB log files if size is changed (pre-MySQL 5.6.8).
+  include: rebuild_ib_logfile.yml
+  when: innodb_log_file_size_changed.rc == 1 and (mysql_version.msg[0][1] | version_compare('5.6.8', 'lt'))

--- a/tasks/rebuild_ib_logfile.yml
+++ b/tasks/rebuild_ib_logfile.yml
@@ -1,0 +1,22 @@
+# file: mysql/tasks/rebuild_ib_logfile.yml
+
+- name: MySQL | Stop MySQL server to change InnoDB log file size.
+  service:
+    name: mysql
+    state: stopped
+
+- name: MySQL | Move InnoDB logs if changing to a different log file size.
+  command: mv /var/lib/mysql/{{ item }} /tmp/{{ item }}
+  with_items:
+    - ib_logfile0
+    - ib_logfile1
+
+- name: MySQL | Start MySQL server after changing InnoDB log file size.
+  service:
+    name: mysql
+    state: started
+
+- name: MySQL | Wait for MySQL to finish startup.
+  wait_for:
+    port: "{{ mysql_port}}"
+    delay: "{{ mysql_remove_ib_logfile_startup_delay }}"


### PR DESCRIPTION
Changing the innodb_log_file_size prior to MySQL version 5.6.8 requires you to stop the server, move the old log files away and start the server again. This patch would automate that and set the default from the tiny 5M that is not enough for almost any site to the one newer MySQL versions default to (48M).