### PR TITLE
Add ability to configure an apt key

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ mysql_bind_address: '0.0.0.0'           # The address the mysql server binds on
 mysql_root_password: ''                 # The new root password
 mysql_default_root_password: ''         # The root password
 mysql_ppa: ''                           # Install MySQL from PPA repository
+mysql_apt_key: ''
 
 # Fine Tuning
 mysql_key_buffer: '16M'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ mysql_default_root_password: ''
 mysql_root_password: 'CHANGEME'
 mysql_language: '/usr/share/mysql/'
 mysql_ppa: ''
+mysql_apt_key: ''
 
 # Fine Tuning
 mysql_key_buffer: '16M'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,7 +1,11 @@
 # file: mysql/tasks/install.yml
 
+- name: MySQL* | Add mysql apt key
+  apt_key: data="{{ mysql_apt_key }}" state=present
+  when: mysql_apt_key != False and mysql_apt_key != ""
+
 - name: MySQL | Add APT repository
-  apt_repository: repo={{mysql_ppa}} update_cache=yes
+  apt_repository: repo="{{mysql_ppa}}" update_cache=yes
   when: mysql_ppa != False and mysql_ppa != ""
 
 - name: MySQL | Make sure the MySQL packages are installed


### PR DESCRIPTION
apt-get install was failing with security-related error messages when
running with Ansible 2.0 and setting `mysql_ppa` to the 5.7 apt repo.
