### PR TITLE
Skip mysql 5.7 incompatible settings for distrubution "xenial"

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,8 +14,3 @@
     update_cache: yes
     cache_valid_time: 3600
   with_items: "{{ mysql_packages }}"
-
-- name: MySQL | Ensure MySQL is running
-  service:
-    name: mysql
-    state: started

--- a/tasks/secure.yml
+++ b/tasks/secure.yml
@@ -1,5 +1,10 @@
 # file: mysql/tasks/secure.yml
 
+- name: MySQL | Ensure MySQL is running
+  service:
+    name: mysql
+    state: started
+
 - name: MySQL | Test whether the root password has already been changed (external hostname).
   mysql_user:
     user: root

--- a/templates/etc_mysql_my.cnf.j2
+++ b/templates/etc_mysql_my.cnf.j2
@@ -33,7 +33,7 @@ thread_cache_size       = {{ mysql_cache_size }}
 max_connections         = {{ mysql_max_connections }}
 table_open_cache        = {{ mysql_table_cache }}
 max_allowed_packet      = {{ mysql_max_allowed_packet }}
-{% if not '5.7' in mysql_ppa %}
+{% if not '5.7' in mysql_ppa and not 'xenial' in ansible_distribution_release %}
 # ** Not compatible with 5.7
 key_buffer              = {{ mysql_key_buffer }}
 myisam-recover          = {{ mysql_myisam_recover }}


### PR DESCRIPTION
This is probably not the best way to solve it, a better way is probably to find out what version is installed. However I don't know how to do that without invoking shell commands and I prefer to avoid that.

This should solve #52 