### PR TITLE
Reorder the 'start mysql' task to after configuring my.cnf

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,8 +14,3 @@
     update_cache: yes
     cache_valid_time: 3600
   with_items: "{{ mysql_packages }}"
-
-- name: MySQL | Ensure MySQL is running
-  service:
-    name: mysql
-    state: started

--- a/tasks/secure.yml
+++ b/tasks/secure.yml
@@ -1,5 +1,10 @@
 # file: mysql/tasks/secure.yml
 
+- name: MySQL | Ensure MySQL is running
+  service:
+    name: mysql
+    state: started
+
 - name: MySQL | Test whether the root password has already been changed (external hostname).
   mysql_user:
     user: root


### PR DESCRIPTION
If for some reason mysql doesn't start, lets say you messed up my.cnf in between runs, this will never finish.

Re-ordered the tasks so that 'start mysql' is done after configuring my.cnf since that task is the only thing between the old position and the new.