### PR TITLE
Fix my.cnf for incompatible options when mysql-server >= 5.7

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,5 +1,9 @@
 # file: mysql/tasks/configure.yml
 
+- name: MySQL | Get version number
+  command: mysql --version | sed -e 's/.*Distrib \([0-9\.]*\).*/\1/'
+  register: mysql_version
+
 - name: MySQL | Update the my.cnf
   template:
     src: etc_mysql_my.cnf.j2

--- a/templates/etc_mysql_my.cnf.j2
+++ b/templates/etc_mysql_my.cnf.j2
@@ -33,7 +33,7 @@ thread_cache_size       = {{ mysql_cache_size }}
 max_connections         = {{ mysql_max_connections }}
 table_open_cache        = {{ mysql_table_cache }}
 max_allowed_packet      = {{ mysql_max_allowed_packet }}
-{% if not '5.7' in mysql_ppa %}
+{% if mysql_version | version_compare('5.7', '<=')  %}
 # ** Not compatible with 5.7
 key_buffer              = {{ mysql_key_buffer }}
 myisam-recover          = {{ mysql_myisam_recover }}


### PR DESCRIPTION
Fixing #52 and #49 since mysql_ppa can be == '' and still installing mysql 5.7